### PR TITLE
Add custom matcher support to vcr_config object.

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -44,7 +44,12 @@ def vcr_cassette(request, vcr_config, vcr_cassette_path):
     if record_mode:
         kwargs['record_mode'] = record_mode
 
+    matchers = kwargs.pop('matchers', {})
+    match_on = kwargs.pop('match_on', [])    
     vcr = VCR(**kwargs)
+    for matcher_name, matcher_func in matchers.items():
+        vcr.register_matcher(matcher_name, matcher_func)
+    vcr.match_on = match_on
     with vcr.use_cassette(vcr_cassette_path) as cassette:
         yield cassette
 

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -45,11 +45,13 @@ def vcr_cassette(request, vcr_config, vcr_cassette_path):
         kwargs['record_mode'] = record_mode
 
     matchers = kwargs.pop('matchers', {})
-    match_on = kwargs.pop('match_on', [])    
+    if matchers:
+        match_on = kwargs.pop('match_on', [])    
     vcr = VCR(**kwargs)
-    for matcher_name, matcher_func in matchers.items():
-        vcr.register_matcher(matcher_name, matcher_func)
-    vcr.match_on = match_on
+    if matchers:
+        for matcher_name, matcher_func in matchers.items():
+            vcr.register_matcher(matcher_name, matcher_func)
+        vcr.match_on = match_on
     with vcr.use_cassette(vcr_cassette_path) as cassette:
         yield cassette
 


### PR DESCRIPTION
I need a custom request matcher supported in my tests, but pytest-vcr doesn't expose the `register_matcher` function to pytest in any way.  I don't know how usable this approach is at the moment, but I thought I would document it here in case it's interesting to anybody.