### PR TITLE
Expose the VCR as a new fixture

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,22 @@ Default: name of the test
 
 Name of the current test's cassette
 
+## vcr
+
+Default: an instance of `VCR`
+
+This is the instance used for creating cassettes.
+You'd override this fixture to register your own matchers, serializers or persisters, for example:
+
+```python
+@pytest.fixture
+def vcr(vcr):
+    vcr.register_matcher('my_matcher', my_matcher)
+    vcr.match_on = ['my_matcher']  # This can also go into vcr_config or marker kwargs
+    return vcr
+```
+
+
 # Marker options
 All options provided on the marker will be passed to the VCR constructor, for example:
 

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -29,9 +29,9 @@ def _vcr_marker(request):
         request.getfixturevalue('vcr_cassette')
 
 
-@pytest.yield_fixture
-def vcr_cassette(request, vcr_config, vcr_cassette_path):
-    """Wrap a test in a VCR.py cassette"""
+@pytest.fixture
+def vcr(request, vcr_config):
+    """The VCR instance"""
     kwargs = dict(
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
@@ -45,6 +45,12 @@ def vcr_cassette(request, vcr_config, vcr_cassette_path):
         kwargs['record_mode'] = record_mode
 
     vcr = VCR(**kwargs)
+    return vcr
+
+
+@pytest.yield_fixture
+def vcr_cassette(vcr, vcr_cassette_path):
+    """Wrap a test in a VCR.py cassette"""
     with vcr.use_cassette(vcr_cassette_path) as cassette:
         yield cassette
 


### PR DESCRIPTION
This way users can add custom matchers, serializers, or even mock the whole instance.

Fixes #1.