### PR TITLE
Add --disable-vcr, --autoblock-network-calls and rename --vcr-record-mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 install:
@@ -15,10 +16,9 @@ install:
   # Using the coveralls-python master until parallel builds support is released
   # See: https://github.com/coveralls-clients/coveralls-python/commit/7ba3a5
   - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || pip install git+https://github.com/coveralls-clients/coveralls-python"
-  - pip install tox coverage
-  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}}"
+  - pip install tox-travis coverage
 script:
-  - tox -e $TOX_ENV
+  - tox -v
   - coverage combine
 after_success:
   - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || COVERALLS_PARALLEL=true coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
 
 init:
   - "%PYTHON%/python -V"
@@ -28,7 +31,7 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+  - "%PYTHON%/Scripts/tox -v -e %TOX_ENV%"
 
 after_test:
   - "%PYTHON%/python setup.py bdist_wheel"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,10 +5,10 @@ or passing options to the vcr marker.
 
 # Command line options
 
-## --vcr-record-mode
+## --vcr-record
 
 Selects the [VCR.py record mode](http://vcrpy.readthedocs.io/en/latest/usage.html#record-modes).
-Useful in CI (where you want --vcr-record-mode=none).
+Useful in CI (where you want --vcr-record=none).
 
 # Configuration fixtures
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,5 +58,5 @@ def vcr_cassette_path(request, vcr_cassette_name):
 
 
 # Running on CI
-When running your tests on CI it's recommended to use the `--vcr-record-mode=none` option.
+When running your tests on CI it's recommended to use the `--vcr-record=none` option.
 This way you can make sure that you have committed all the cassettes.

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -41,8 +41,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.fixture(autouse=True)
 def _vcr_marker(request):
     marker = request.node.get_marker('vcr')
-    disable_vcr = request.config.getoption('--disable-vcr')
-    if marker and not disable_vcr:
+    if marker:
         request.getfixturevalue('vcr_cassette')
 
 
@@ -65,6 +64,12 @@ def vcr(request, vcr_config, pytestconfig):
         kwargs.update(marker.kwargs)
     if record_mode:
         kwargs['record_mode'] = record_mode
+
+    disable_vcr = request.config.getoption('--disable-vcr')
+    if disable_vcr:
+        # Set mode to record but discard all responses to disable both recording and playback
+        kwargs['record_mode'] = 'new_episodes'
+        kwargs['before_record_response'] = lambda *args, **kwargs: None
 
     vcr = VCR(**kwargs)
     return vcr

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+
 import pytest
 from vcr import VCR
 
@@ -13,6 +14,15 @@ def pytest_addoption(parser):
         default=None,
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
+    )
+    # TODO: deprecated, remove in a future release
+    group.addoption(
+        '--vcr-record-mode',
+        action='store',
+        dest='vcr_record',
+        default=None,
+        choices=['once', 'new_episodes', 'none', 'all'],
+        help='DEPRECATED: use --vcr-record'
     )
     group.addoption(
         '--disable-vcr',
@@ -37,13 +47,18 @@ def _vcr_marker(request):
 
 
 @pytest.fixture
-def vcr(request, vcr_config):
+def vcr(request, vcr_config, pytestconfig):
     """The VCR instance"""
     kwargs = dict(
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
     marker = request.node.get_marker('vcr')
-    record_mode = request.config.getoption('--vcr-record')
+    record_mode = request.config.getoption('--vcr-record-mode')
+    if record_mode:
+        pytestconfig.warn("C1",
+                          "--vcr-record-mode has been deprecated and will be removed in a future "
+                          "release. Use --vcr-record instead.")
+    record_mode = request.config.getoption('--vcr-record') or record_mode
 
     kwargs.update(vcr_config)
     if marker:

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -7,9 +7,9 @@ from vcr import VCR
 def pytest_addoption(parser):
     group = parser.getgroup('vcr')
     group.addoption(
-        '--vcr-record-mode',
+        '--vcr-record',
         action='store',
-        dest='vcr_record_mode',
+        dest='vcr_record',
         default=None,
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
@@ -36,7 +36,7 @@ def vcr(request, vcr_config):
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
     marker = request.node.get_marker('vcr')
-    record_mode = request.config.getoption('--vcr-record-mode')
+    record_mode = request.config.getoption('--vcr-record')
 
     kwargs.update(vcr_config)
     if marker:

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -14,6 +14,12 @@ def pytest_addoption(parser):
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
     )
+    group.addoption(
+        '--disable-vcr',
+        action='store_true',
+        dest='disable_vcr',
+        help='Run tests without playing back from VCR.py cassettes'
+    )
 
 
 def pytest_load_initial_conftests(early_config, parser, args):
@@ -25,7 +31,8 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.fixture(autouse=True)
 def _vcr_marker(request):
     marker = request.node.get_marker('vcr')
-    if marker:
+    disable_vcr = request.config.getoption('--disable-vcr')
+    if marker and not disable_vcr:
         request.getfixturevalue('vcr_cassette')
 
 

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -27,6 +27,27 @@ def test_iana_example(testdir):
     assert cassette_path.size() > 50
 
 
+def test_disable_vcr(testdir):
+    testdir.makepyfile(**{'subdir/test_iana_example': """
+        import pytest
+        try:
+            from urllib.request import urlopen
+        except ImportError:
+            from urllib2 import urlopen
+
+        @pytest.mark.vcr
+        def test_disable_vcr_iana():
+            response = urlopen('http://www.iana.org/domains/reserved').read()
+            assert b'Example domains' in response
+    """})
+
+    result = testdir.runpytest('--disable-vcr', '-v')
+    result.assert_outcomes(1, 0, 0)
+
+    cassette_dir_path = testdir.tmpdir.join('subdir', 'cassettes')
+    assert not cassette_dir_path.check()
+
+
 def test_custom_matchers(testdir):
     testdir.makepyfile("""
         import pytest

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -174,6 +174,25 @@ def test_overriding_record_mode(testdir):
     result.stdout.fnmatch_lines(['*Cassette record mode: all'])
 
 
+def test_deprecated_record_mode(testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture
+        def vcr_config():
+            return {'record_mode': 'none'}
+
+        @pytest.mark.vcr(record_mode='once')
+        def test_method(vcr_cassette):
+            print("Cassette record mode: {}".format(vcr_cassette.record_mode))
+    """)
+
+    result = testdir.runpytest('-s', '--vcr-record-mode', 'all')
+    result.assert_outcomes(1, 0, 0)
+    result.stdout.fnmatch_lines(['*Cassette record mode: all',
+                                 '*--vcr-record-mode has been deprecated*'])
+
+
 def test_marking_whole_class(testdir):
     testdir.makepyfile("""
         import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py33,py34,py35,pypy,flake8,mkdocs
+envlist = py27,py33,py34,py35,py36,pypy,flake8,mkdocs
 
 [testenv]
 deps =


### PR DESCRIPTION
Thank you for this fantastic little plugin! The `@pytest.mark.vcr` decorators are really convenient and clever and the code very well crafted, too. I can't wait to use this in my codebase.  😃 

I have some improvement suggestions, which I have implemented in this PR:
* Rename `--vcr-record-mode` → `--vcr-record`. This option gets used a lot during testing, so it's good to keep it short and easy to type. It also makes the option read more like a natural sentence, e.g. `--vcr-record all`, `--vcr-record once`. This breaks backwards compatibility somewhat, but I assume it should not be a huge issue as this plugin is still in alpha status.
* Add `--disable-vcr`, which makes it possible to run tests without either playing back from or recording VCR.py cassettes.
* Add `--autoblock-network-calls`, which blocks all network calls when in `none` recording mode. This can be used to ensure that all tests have been perfectly covered by VCR.py. This relies on the `pytest-socket` plugin, specifically on [my personal fork](https://github.com/valgur/pytest-socket) of it until it gets merged and some issues ironed out. I expect this feature to be used mostly via `pytest.ini` by adding
```INI
[pytest]
addopts = --autoblock-network-calls
```

What do you think? I'll gladly take care of updating the documentation as well once this PR gets a green light and is ready to be merged.