### PR TITLE
Add support for use in fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 install:
@@ -15,10 +16,9 @@ install:
   # Using the coveralls-python master until parallel builds support is released
   # See: https://github.com/coveralls-clients/coveralls-python/commit/7ba3a5
   - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || pip install git+https://github.com/coveralls-clients/coveralls-python"
-  - pip install tox coverage
-  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}}"
+  - pip install tox-travis coverage
 script:
-  - tox -e $TOX_ENV
+  - tox -v
   - coverage combine
 after_success:
   - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || COVERALLS_PARALLEL=true coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
 
 init:
   - "%PYTHON%/python -V"
@@ -28,7 +31,7 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+  - "%PYTHON%/Scripts/tox -v -e %TOX_ENV%"
 
 after_test:
   - "%PYTHON%/python setup.py bdist_wheel"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,10 +5,10 @@ or passing options to the vcr marker.
 
 # Command line options
 
-## --vcr-record-mode
+## --vcr-record
 
 Selects the [VCR.py record mode](http://vcrpy.readthedocs.io/en/latest/usage.html#record-modes).
-Useful in CI (where you want --vcr-record-mode=none).
+Useful in CI (where you want --vcr-record=none).
 
 # Configuration fixtures
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,5 +58,5 @@ def vcr_cassette_path(request, vcr_cassette_name):
 
 
 # Running on CI
-When running your tests on CI it's recommended to use the `--vcr-record-mode=none` option.
+When running your tests on CI it's recommended to use the `--vcr-record=none` option.
 This way you can make sure that you have committed all the cassettes.

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -41,8 +41,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.fixture(autouse=True)
 def _vcr_marker(request):
     marker = request.node.get_marker('vcr')
-    disable_vcr = request.config.getoption('--disable-vcr')
-    if marker and not disable_vcr:
+    if marker:
         request.getfixturevalue('vcr_cassette')
 
 
@@ -65,6 +64,12 @@ def vcr(request, vcr_config, pytestconfig):
         kwargs.update(marker.kwargs)
     if record_mode:
         kwargs['record_mode'] = record_mode
+
+    disable_vcr = request.config.getoption('--disable-vcr')
+    if disable_vcr:
+        # Set mode to record but discard all responses to disable both recording and playback
+        kwargs['record_mode'] = 'new_episodes'
+        kwargs['before_record_response'] = lambda *args, **kwargs: None
 
     vcr = VCR(**kwargs)
     return vcr

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -46,9 +46,10 @@ def _vcr_marker(request):
 
 
 @pytest.fixture
-def vcr(request, vcr_config, pytestconfig):
+def vcr(request, vcr_config, vcr_cassette_dir, pytestconfig):
     """The VCR instance"""
     kwargs = dict(
+        cassette_library_dir=vcr_cassette_dir,
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
     marker = request.node.get_marker('vcr')
@@ -75,11 +76,17 @@ def vcr(request, vcr_config, pytestconfig):
     return vcr
 
 
-@pytest.yield_fixture
-def vcr_cassette(vcr, vcr_cassette_path):
+@pytest.fixture
+def vcr_cassette(vcr, vcr_cassette_name):
     """Wrap a test in a VCR.py cassette"""
-    with vcr.use_cassette(vcr_cassette_path) as cassette:
+    with vcr.use_cassette(vcr_cassette_name) as cassette:
         yield cassette
+
+
+@pytest.fixture
+def vcr_cassette_dir(request):
+    test_dir = request.node.fspath.dirname
+    return os.path.join(test_dir, 'cassettes')
 
 
 @pytest.fixture
@@ -89,12 +96,6 @@ def vcr_cassette_name(request):
     if hasattr(f, '__self__'):
         return f.__self__.__class__.__name__ + '.' + request.node.name
     return request.node.name
-
-
-@pytest.fixture
-def vcr_cassette_path(request, vcr_cassette_name):
-    test_dir = request.node.fspath.dirname
-    return os.path.join(test_dir, 'cassettes', vcr_cassette_name)
 
 
 @pytest.fixture

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+
 import pytest
 from vcr import VCR
 
@@ -13,6 +14,15 @@ def pytest_addoption(parser):
         default=None,
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
+    )
+    # TODO: deprecated, remove in a future release
+    group.addoption(
+        '--vcr-record-mode',
+        action='store',
+        dest='vcr_record',
+        default=None,
+        choices=['once', 'new_episodes', 'none', 'all'],
+        help='DEPRECATED: use --vcr-record'
     )
     group.addoption(
         '--disable-vcr',
@@ -37,13 +47,18 @@ def _vcr_marker(request):
 
 
 @pytest.fixture
-def vcr(request, vcr_config):
+def vcr(request, vcr_config, pytestconfig):
     """The VCR instance"""
     kwargs = dict(
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
     marker = request.node.get_marker('vcr')
-    record_mode = request.config.getoption('--vcr-record')
+    record_mode = request.config.getoption('--vcr-record-mode')
+    if record_mode:
+        pytestconfig.warn("C1",
+                          "--vcr-record-mode has been deprecated and will be removed in a future "
+                          "release. Use --vcr-record instead.")
+    record_mode = request.config.getoption('--vcr-record') or record_mode
 
     kwargs.update(vcr_config)
     if marker:

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -7,9 +7,9 @@ from vcr import VCR
 def pytest_addoption(parser):
     group = parser.getgroup('vcr')
     group.addoption(
-        '--vcr-record-mode',
+        '--vcr-record',
         action='store',
-        dest='vcr_record_mode',
+        dest='vcr_record',
         default=None,
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
@@ -36,7 +36,7 @@ def vcr(request, vcr_config):
         path_transformer=VCR.ensure_suffix(".yaml"),
     )
     marker = request.node.get_marker('vcr')
-    record_mode = request.config.getoption('--vcr-record-mode')
+    record_mode = request.config.getoption('--vcr-record')
 
     kwargs.update(vcr_config)
     if marker:

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -14,6 +14,12 @@ def pytest_addoption(parser):
         choices=['once', 'new_episodes', 'none', 'all'],
         help='Set the recording mode for VCR.py.'
     )
+    group.addoption(
+        '--disable-vcr',
+        action='store_true',
+        dest='disable_vcr',
+        help='Run tests without playing back from VCR.py cassettes'
+    )
 
 
 def pytest_load_initial_conftests(early_config, parser, args):
@@ -25,7 +31,8 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.fixture(autouse=True)
 def _vcr_marker(request):
     marker = request.node.get_marker('vcr')
-    if marker:
+    disable_vcr = request.config.getoption('--disable-vcr')
+    if marker and not disable_vcr:
         request.getfixturevalue('vcr_cassette')
 
 

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -27,6 +27,27 @@ def test_iana_example(testdir):
     assert cassette_path.size() > 50
 
 
+def test_disable_vcr(testdir):
+    testdir.makepyfile(**{'subdir/test_iana_example': """
+        import pytest
+        try:
+            from urllib.request import urlopen
+        except ImportError:
+            from urllib2 import urlopen
+
+        @pytest.mark.vcr
+        def test_disable_vcr_iana():
+            response = urlopen('http://www.iana.org/domains/reserved').read()
+            assert b'Example domains' in response
+    """})
+
+    result = testdir.runpytest('--disable-vcr', '-v')
+    result.assert_outcomes(1, 0, 0)
+
+    cassette_dir_path = testdir.tmpdir.join('subdir', 'cassettes')
+    assert not cassette_dir_path.check()
+
+
 def test_custom_matchers(testdir):
     testdir.makepyfile("""
         import pytest

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -76,7 +76,7 @@ def test_disable_vcr_with_existing_cassette(testdir):
         except ImportError:
             from urllib2 import urlopen
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr(vcr):
             # Make sure that modifying the VCR instance does not break anything
             vcr.register_matcher('xx', lambda x: x)
@@ -137,7 +137,7 @@ def test_custom_matchers(testdir):
         except ImportError:
             from urllib2 import urlopen
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr(vcr):
             vcr.register_matcher('my_matcher', lambda a, b: True)
             vcr.match_on = ['my_matcher']

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -174,6 +174,25 @@ def test_overriding_record_mode(testdir):
     result.stdout.fnmatch_lines(['*Cassette record mode: all'])
 
 
+def test_deprecated_record_mode(testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture
+        def vcr_config():
+            return {'record_mode': 'none'}
+
+        @pytest.mark.vcr(record_mode='once')
+        def test_method(vcr_cassette):
+            print("Cassette record mode: {}".format(vcr_cassette.record_mode))
+    """)
+
+    result = testdir.runpytest('-s', '--vcr-record-mode', 'all')
+    result.assert_outcomes(1, 0, 0)
+    result.stdout.fnmatch_lines(['*Cassette record mode: all',
+                                 '*--vcr-record-mode has been deprecated*'])
+
+
 def test_marking_whole_class(testdir):
     testdir.makepyfile("""
         import pytest

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -52,7 +52,7 @@ def test_disable_vcr(testdir):
             response = urlopen('http://www.iana.org/domains/reserved').read()
             assert b'Example domains' in response
 
-        def test_disable_vcr_iana_vcr(vcr_cassette, vcr):
+        def test_disable_vcr_iana_vcr(vcr):
             with vcr.use_cassette('test_disable_vcr_iana_vcr'):
                 response = urlopen('http://www.iana.org/domains/reserved').read()
             assert b'Example domains' in response

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -171,7 +171,7 @@ def test_overriding_cassette_path(testdir):
     testdir.makepyfile("""
         import pytest, os
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr_cassette_dir():
             return 'vhs'
 
@@ -208,7 +208,7 @@ def test_vcr_config(testdir):
     testdir.makepyfile("""
         import pytest
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr_config():
             return {'record_mode': 'none'}
 
@@ -226,7 +226,7 @@ def test_marker_options(testdir):
     testdir.makepyfile("""
         import pytest
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr_config():
             return {'record_mode': 'all'}
 
@@ -244,14 +244,13 @@ def test_overriding_record_mode(testdir):
     testdir.makepyfile("""
         import pytest
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr_config():
             return {'record_mode': 'none'}
 
         @pytest.mark.vcr(record_mode='once')
         def test_method(vcr_cassette, vcr):
             print("Cassette record mode: {}".format(vcr_cassette.record_mode))
-            assert vcr.record_mode == 'all'
     """)
 
     result = testdir.runpytest('-s', '--vcr-record', 'all')
@@ -263,7 +262,7 @@ def test_deprecated_record_mode(testdir):
     testdir.makepyfile("""
         import pytest
 
-        @pytest.fixture
+        @pytest.fixture(scope='module')
         def vcr_config():
             return {'record_mode': 'none'}
 
@@ -343,7 +342,6 @@ def test_use_in_function_scope_fixture(testdir):
     assert cassette_path.size() > 50
 
 
-@pytest.mark.xfail(reason="module-scoped fixtures are not supported")
 def test_use_in_module_scope_fixture(testdir):
     testdir.makepyfile(**{'subdir/test_iana_example': """
         import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py33,py34,py35,pypy,flake8,mkdocs
+envlist = py27,py33,py34,py35,py36,pypy,flake8,mkdocs
 
 [testenv]
 deps =


### PR DESCRIPTION
Implements the changes I suggested in https://github.com/ktosiek/pytest-vcr/pull/5#issuecomment-312238773.

* `vcr_cassette_path` has been replaced with `vcr_cassette_dir`, which is used to initialize the VCR object. This makes it possible to use the following pattern:
```
def test_something(vcr):
    with vcr.use_cassette('test_something', ...kwargs...):
        ...
```
* Extend fixtures' scope to `'module'` so they can be used in fixtures with a wider scope. `'session'` would be preferred, but the test directory path can not be obtained at that scope. This means that the VCR object is instantiated once per module rather than for every test, which is preferable anyway, I think. The only downside is that overriding fixtures becomes slightly more verbose: you have to include the `scope='module'` bit.