### PR TITLE
Update marker usage to avoid deprecation warnings in pytest 3.6+

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -40,13 +40,13 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
 @pytest.fixture(autouse=True)
 def _vcr_marker(request):
-    marker = request.node.get_marker('vcr')
+    marker = request.node.get_closest_marker('vcr')
     if marker:
         request.getfixturevalue('vcr_cassette')
 
 
 def _update_kwargs(request, kwargs):
-    marker = request.node.get_marker('vcr')
+    marker = request.node.get_closest_marker('vcr')
     if marker:
         kwargs.update(marker.kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='Plugin for managing VCR.py cassettes',
     long_description=read('README.rst'),
     py_modules=['pytest_vcr'],
-    install_requires=['pytest>=3.0.0', 'vcrpy'],
+    install_requires=['pytest>=3.6.0', 'vcrpy'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Pytest',


### PR DESCRIPTION
pytest 3.6 revamped markers and deprecated the existing API: https://docs.pytest.org/en/latest/mark.html#updating-code