### PR TITLE
Fix --vcr-record-mode deprecation warning

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import warnings
 
 import pytest
 from vcr import VCR
@@ -19,7 +20,7 @@ def pytest_addoption(parser):
     group.addoption(
         '--vcr-record-mode',
         action='store',
-        dest='vcr_record',
+        dest='deprecated_vcr_record',
         default=None,
         choices=['once', 'new_episodes', 'none', 'all'],
         help='DEPRECATED: use --vcr-record'
@@ -62,12 +63,12 @@ def _update_kwargs(request, kwargs):
 
 
 @pytest.fixture(scope='module')
-def vcr(request, pytestconfig, vcr_config, vcr_cassette_dir, ):
+def vcr(request, vcr_config, vcr_cassette_dir, ):
     """The VCR instance"""
     if request.config.getoption('--vcr-record-mode'):
-        pytestconfig.warn("C1",
-                          "--vcr-record-mode has been deprecated and will be removed in a future "
-                          "release. Use --vcr-record instead.")
+        warnings.warn("--vcr-record-mode has been deprecated and will be removed in a future "
+                      "release. Use --vcr-record instead.",
+                      DeprecationWarning)
     kwargs = dict(
         cassette_library_dir=vcr_cassette_dir,
         path_transformer=VCR.ensure_suffix(".yaml"),

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -254,6 +254,24 @@ def test_overriding_record_mode(testdir):
     result.stdout.fnmatch_lines(['*Cassette record mode: all'])
 
 
+def test_no_warnings(testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture(scope='module')
+        def vcr_config():
+            return {'record_mode': 'none'}
+
+        @pytest.mark.vcr(record_mode='once')
+        def test_method(vcr_cassette):
+            print("Cassette record mode: {}".format(vcr_cassette.record_mode))
+    """)
+
+    result = testdir.runpytest('-s', '--vcr-record', 'all')
+    result.assert_outcomes(1, 0, 0)
+    assert 'warnings summary' not in result.stdout.str()
+
+
 def test_deprecated_record_mode(testdir):
     testdir.makepyfile("""
         import pytest


### PR DESCRIPTION
Without these changes, the `--vcr-record-mode` deprecation warning would also be displayed when using the non-deprecated `--vcr-record` option.  Additionally it raised the warning in a deprecated way.

```
--vcr-record-mode has been deprecated and will be removed in a future
release. Use --vcr-record instead.

test_no_warnings.py::test_method
 unknown file:0: RemovedInPytest4Warning: config.warn has been deprecated,
use warnings.warn instead
```

This can be verified by running the test in the first commit.