### PR TITLE
Mark vcr_config fixture as module scoped

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ It's important to make sure you aren't leaving any secrets in your cassettes.
 For example, when using HTTP Basic authentication, you should add this to your conftest:
 
 ```python
-@pytest.fixture
+@pytest.fixture(scope='module')
 def vcr_config():
     return {
         # Replace the Authorization request header with "DUMMY" in cassettes


### PR DESCRIPTION
I got an error about it being function scoped which is the default behaviour without doing this. This  change matches the vcr_cassette_dir fixture later on in the docs.