### PR TITLE
fix - regression on handling the cassette name in a class that inherits from unittest.TestCase

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -97,9 +97,9 @@ def vcr_cassette_dir(request):
 @pytest.fixture
 def vcr_cassette_name(request):
     """Name of the VCR cassette"""
-    f = request.function
-    if hasattr(f, '__self__'):
-        return f.__self__.__class__.__name__ + '.' + request.node.name
+    test_class = request.cls
+    if test_class:
+        return "{}.{}".format(test_class.__name__, request.node.name)
     return request.node.name
 
 

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from unittest import TestCase
 
 import pytest
 
@@ -430,3 +431,25 @@ def test_marker_message(testdir):
     result.stdout.fnmatch_lines([
         '@pytest.mark.vcr: Mark the test as using VCR.py.',
     ])
+
+
+def test_vcr_cassette_name_function(vcr_cassette_name):
+    assert vcr_cassette_name == "test_vcr_cassette_name_function"
+
+
+class TestSimpleClass(object):
+
+    def test_vcr_cassette_name_class(self, vcr_cassette_name):
+        assert vcr_cassette_name == "TestSimpleClass.test_vcr_cassette_name_class"
+
+
+@pytest.fixture
+def vcr_cassette_name_test_case(request, vcr_cassette_name):
+    request.cls.vcr_cassette_name = vcr_cassette_name
+
+
+@pytest.mark.usefixtures("vcr_cassette_name_test_case")
+class TestUnitTestClass(TestCase):
+
+    def test_vcr_cassette_name_class(self):
+        assert self.vcr_cassette_name == "TestUnitTestClass.test_vcr_cassette_name_class"


### PR DESCRIPTION
A weird thing happens with pytest 4.X.X when using vcr on a "unittest.TestCase" class, the cassette name do not have the class name anymore compared with pytest 3.X.X.

The cassette name did not include the class name if it inherits from unittest.TestCase, use the attribute "request.cls" to get the class instead of relying on hasattr(request.function, '__self__').