### PR TITLE
problem in cassette_name

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 import warnings
 
 import pytest
@@ -99,8 +100,11 @@ def vcr_cassette_name(request):
     """Name of the VCR cassette"""
     test_class = request.cls
     if test_class:
-        return "{}.{}".format(test_class.__name__, request.node.name)
-    return request.node.name
+        cassette_name = "{}.{}".format(test_class.__name__, request.node.name)
+    else:
+        cassette_name = request.node.name
+    # remove forbidden characters in the filename 
+    return re.sub(r'[<>?%*:|"/\\]+', '-', cassette_name)
 
 
 @pytest.fixture(scope='module')

--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -103,7 +103,7 @@ def vcr_cassette_name(request):
         cassette_name = "{}.{}".format(test_class.__name__, request.node.name)
     else:
         cassette_name = request.node.name
-    # remove forbidden characters in the filename 
+    # remove forbidden characters in the filename
     return re.sub(r'[<>?%*:|"/\\]+', '-', cassette_name)
 
 

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -320,7 +320,7 @@ def test_separate_cassettes_for_parametrized_tests(testdir):
         import pytest
 
         @pytest.mark.vcr
-        @pytest.mark.parametrize('arg', ['a', 'b'])
+        @pytest.mark.parametrize('arg', ['a', 'b', 'Z', '1', '_', '-'])
         def test_parameters(arg, vcr_cassette_name):
             assert vcr_cassette_name == 'test_parameters[{}]'.format(arg)
     """)
@@ -328,6 +328,18 @@ def test_separate_cassettes_for_parametrized_tests(testdir):
     result = testdir.runpytest('-s')
     assert result.ret == 0
 
+def test_separate_cassettes_for_parametrized_tests_forbidden_character(testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.vcr
+        @pytest.mark.parametrize('arg', ['/', '\\\\', '?', '%', '*', ':', '|', '"', '<', '>'])
+        def test_parameters(arg, vcr_cassette_name):
+            assert vcr_cassette_name == 'test_parameters[-]' 
+    """)
+
+    result = testdir.runpytest('-s')
+    assert result.ret == 0
 
 def test_use_in_function_scope_fixture(testdir, live_server):
     """Test that the VCR instance can be used from fixtures and that the cassettes

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -328,6 +328,7 @@ def test_separate_cassettes_for_parametrized_tests(testdir):
     result = testdir.runpytest('-s')
     assert result.ret == 0
 
+
 def test_separate_cassettes_for_parametrized_tests_forbidden_character(testdir):
     testdir.makepyfile("""
         import pytest
@@ -335,11 +336,12 @@ def test_separate_cassettes_for_parametrized_tests_forbidden_character(testdir):
         @pytest.mark.vcr
         @pytest.mark.parametrize('arg', ['/', '\\\\', '?', '%', '*', ':', '|', '"', '<', '>'])
         def test_parameters(arg, vcr_cassette_name):
-            assert vcr_cassette_name == 'test_parameters[-]' 
+            assert vcr_cassette_name == 'test_parameters[-]'
     """)
 
     result = testdir.runpytest('-s')
     assert result.ret == 0
+
 
 def test_use_in_function_scope_fixture(testdir, live_server):
     """Test that the VCR instance can be used from fixtures and that the cassettes


### PR DESCRIPTION
Hi Tomasz,

First, thank you for the pytest-vcr plugin :)

I have a small problem in one of my project with the cassette name. Some of my tests have pytest parameters that include a slash ”/” so it’s impact the cassette_name (in fact, that create a directory). 

I have fixed this problem by replacing the “/” (and others forbidden characters in filename in Windows) by a dash “-”. 

Here it’s a PR for this fix. 

I wish the fix could be integrated in pytest-vcr. I will be happy to contribute to this plugin.

Have a good day,

Regards,

Clément