### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+recursive-include tests/ *.py
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.

Fixes #26 