### PR TITLE
Fix typo in filter_headers docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ For example, when using HTTP Basic authentication, you should add this to your c
 def vcr_config():
     return {
         # Replace the Authorization request header with "DUMMY" in cassettes
-        filter_headers: [('authorization', 'DUMMY')],
+        "filter_headers": [('authorization', 'DUMMY')],
     }
 ```
 


### PR DESCRIPTION
Fix for an example of "filter_headers" usage. It should be a string. 