### PR TITLE
Use a released version of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,7 @@ jobs:
     - env: PYTEST=master
 
 install:
-  # coveralls-python needs a newer setuptools to install from git
-  - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || pip install --upgrade setuptools pip"
-  # Using the coveralls-python master until parallel builds support is released
-  # See: https://github.com/coveralls-clients/coveralls-python/commit/7ba3a5
-  - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || pip install git+https://github.com/coveralls-clients/coveralls-python"
+  - "[[ $TRAVIS_PYTHON_VERSION == pypy ]] || pip install coveralls"
   - pip install tox-travis coverage
 script:
   - tox -v


### PR DESCRIPTION
Parallel builds have been supported for a few versions now.