### PR TITLE
add --vcr-mode=refresh pseudo mode

### DIFF
--- a/pytest_vcr.py
+++ b/pytest_vcr.py
@@ -85,7 +85,8 @@ def vcr_cassette(request, vcr, vcr_cassette_name):
     kwargs = {}
     _update_kwargs(request, kwargs)
 
-    if kwargs["record_mode"] == "refresh":
+    refresh = False
+    if kwargs.get("record_mode") == "refresh":
         refresh = True
         kwargs["record_mode"] = 'all'
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
 import codecs
+import os
+
 from setuptools import setup
 
 
@@ -13,7 +14,7 @@ def read(fname):
 
 setup(
     name='pytest-vcr',
-    version='1.0.2',
+    version='1.0.3',
     author='Tomasz Kontusz',
     author_email='tomasz.kontusz@gmail.com',
     maintainer='Tomasz Kontusz',


### PR DESCRIPTION
`--vcr-record=all` doesn't actually re-record the cassette but keeps or update (if there is a match) any previous episode and append the new ones.(see [an example](https://gist.github.com/mgaitan/3a1a901e0bdda319009e6de59a4fee7e)).

That's the reason why we generally recommend to delete the yaml file in advance and recreate it from scratch, but it's tedious. (and this is particularly important if the test match on the request's body)

`--vcr-record=refresh` delete and start recording from scratch. 